### PR TITLE
For #124, and #126 issues

### DIFF
--- a/custom_node_modules/main/pty.js
+++ b/custom_node_modules/main/pty.js
@@ -1073,7 +1073,7 @@ let bashSession = (window, data) => {
     process.write(`export PATH=$PATH:~/.rd/bin:~/homebrew/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin:/usr/sbin` + OS.EOL)
 
   // Immediately attempt to execute the command of executing `bash` inside the first Cassandra®'s node container
-  process.write(`docker-compose -p "${data.projectID}" exec "cassandra-0" /bin/bash` + OS.EOL)
+  process.write(`${data.dockerComposeBinary} -p "${data.projectID}" exec "cassandra-0" /bin/bash` + OS.EOL)
 
   // When receiving any data from the instance send it to the provided window
   process.on('data', (_data) => window.webContents.send(`pty:${data.id}:data:bash-session`, _data))

--- a/custom_node_modules/renderer/docker.js
+++ b/custom_node_modules/renderer/docker.js
@@ -25,7 +25,13 @@ const YAML = require('js-yaml')
 const DockerContainersPath = Path.join((extraResourcesPath != null ? Path.join(extraResourcesPath) : Path.join(__dirname, '..', '..')), 'data', 'docker')
 
 /**
- * The docker-compose class with different attributes and methods
+ * Set the default docker compose binary to be used
+ * Will be updated with `docker-compose` if needed
+ */
+let dockerComposeBinary = 'docker compose'
+
+/**
+ * The Docker compose class with different attributes and methods
  * With each docker container an instance from this class is created
  */
 class DockerCompose {
@@ -48,7 +54,7 @@ class DockerCompose {
   }
 
   /**
-   * Create a docker-compose YAML file
+   * Create a Docker compose YAML file
    *
    * Cassandra®'s version can be chosen, values are [3.11, 4.0 (default)]
    */
@@ -273,7 +279,7 @@ class DockerCompose {
   }
 
   /**
-   * Start/Up a docker container using `docker-compose`
+   * Start/Up a docker container using `docker compose`
    *
    * A callback function should be passed, it'll receive a boolean value based on the success of the process
    * The name of the container can be passed, if it hasn't then the instance's container's name will be used
@@ -287,8 +293,8 @@ class DockerCompose {
       addLog(`Start docker/sandbox project in path '${Path.join(DockerContainersPath, this.folderName)}' under name 'cassandra_${containerName}'`, 'process')
     } catch (e) {}
 
-    // Execute the `docker-compose` command
-    Terminal.spawn(`cd "${Path.join(DockerContainersPath, this.folderName)}" && docker-compose -p "cassandra_${containerName}" up -d`, pinnedToastID, 'start', (error, stdout, stderr) => {
+    // Execute the `docker compose` command
+    Terminal.spawn(`cd "${Path.join(DockerContainersPath, this.folderName)}" && ${dockerComposeBinary} -p "cassandra_${containerName}" up -d`, pinnedToastID, 'start', (error, stdout, stderr) => {
       // Set the command execution status
       let status = !error || ([error, stderr, stdout]).some((output) => `${output}`.match(/is already in use/gm) != null),
         // Set the final error details to be adopted
@@ -335,7 +341,7 @@ class DockerCompose {
   }
 
   /**
-   * Stop/Down a docker container using `docker-compose`
+   * Stop/Down a docker container using `docker compose`
    *
    * A callback function should be passed, it'll receive a boolean value based on the success of the process
    * The name of the container can be passed, if it hasn't then the instance's container's name will be used
@@ -349,8 +355,8 @@ class DockerCompose {
       addLog(`Stop docker/sandbox project in path '${Path.join(DockerContainersPath, this.folderName)}' under name 'cassandra_${containerName}'`, 'process')
     } catch (e) {}
 
-    // Execute the `docker-compose` command
-    Terminal.spawn(`cd "${Path.join(DockerContainersPath, this.folderName)}" && docker-compose -p "cassandra_${this.containerName}" down`, pinnedToastID, 'stop', (error, stdout, stderr) => {
+    // Execute the `docker compose` command
+    Terminal.spawn(`cd "${Path.join(DockerContainersPath, this.folderName)}" && ${dockerComposeBinary} -p "cassandra_${this.containerName}" down`, pinnedToastID, 'stop', (error, stdout, stderr) => {
       // Set the final error details to be adopted
       let finalError = error || stderr
 
@@ -396,48 +402,87 @@ class DockerCompose {
 }
 
 /**
- * Check if the host machine has a docker-compose installed, and - on Linux - if the current user is in the `docker` group
+ * Check if the host machine has either `docker-compose` or `docker compose` installed, and - on Linux - if the current user is in the `docker` group
  * Works on all major operating systems (Linux, macOS, and Windows)
  *
  * @Parameters:
  * {object} `callback` function that will be triggered with passing the final result
  *
- * @Return: {boolean} the host machine has a docker-compose and the user is in the docker group or not
+ * @Return: {boolean} the host machine has either `docker-compose` or `docker compose` and the user is in the docker group or not
  */
 let checkDockerCompose = (callback) => {
-  // Check if `docker-compose` is installed
-  Terminal.run('docker-compose -v', (err, stderr, data) => {
-    // Whether or not `docker-compose` is installed
-    let isDockerComposeInstalled = !err || `${err}`.toLowerCase().indexOf('version') != -1
-
-    // Add log about this process
-    try {
-      addLog(`Check docker and docker-compose exist in the host machine. Output is:
-        ${err || stderr || data}`)
-    } catch (e) {}
-
-    // If the host OS not Linux then there's no need to check out the `docker` group and just call the callback function
-    if (OS.platform() != 'linux')
-      return callback(isDockerComposeInstalled, true)
-
-    // Check if the current user in the `docker` group
-    Terminal.run('groups', (err, stderr, data) => {
-      // Get any possible output
-      let output = data || err || stderr,
-        // Whether or not the user in the `docker` group
-        isUserInDockerGroup = minifyText(`${output}`).indexOf('docker') != -1
-
+  // Inner function to check the given command and call a callback function
+  let checkProcess = (command, callback) => Terminal.run(command, (err, data, stderr) => {
       // Add log about this process
       try {
-        addLog(`Check the current user is in the docker group. Output is:
-          ${err || stderr || data}`)
+        addLog(`Check if docker and docker-compose exist in the host machine with command '${command}'. Output is:
+        ${err || data || stderr}`)
       } catch (e) {}
 
-      // Call the callback function with the final result
-      callback(isDockerComposeInstalled, isUserInDockerGroup)
-    })
+      // Call the callback function with the checking result
+      callback(!err || [data, stderr].some((output) => `${output}`.toLowerCase().indexOf('version') != -1))
+    }),
+    // Inner function to be executed after the checking process
+    postCheck = (isDockerComposeInstalled) => {
+      // If the host OS not Linux then there's no need to check out the `docker` group and just call the callback function
+      if (OS.platform() != 'linux')
+        return callback(isDockerComposeInstalled, true)
+
+      // Check if the current user in the `docker` group
+      Terminal.run('groups', (err, data, stderr) => {
+        // Get any possible output
+        let output = stderr || err || data,
+          // Whether or not the user in the `docker` group
+          isUserInDockerGroup = minifyText(`${output}`).indexOf('docker') != -1
+
+        // Add log about this process
+        try {
+          addLog(`Check the current user is in the docker group. Output is:
+        ${err || data || stderr}`)
+        } catch (e) {}
+
+        // Call the callback function with the final result
+        callback(isDockerComposeInstalled, isUserInDockerGroup)
+      })
+    }
+
+  // Start with `docker compose`
+  checkProcess('docker compose version', (exist) => {
+    try {
+      // If it's not exist then skip try-catch block
+      if (!exist)
+        throw 0
+
+      // Update the associated variable
+      dockerComposeBinary = 'docker compose'
+
+      // Call the post checking process function
+      postCheck(exist)
+
+      // Skip the upcoming code
+      return
+    } catch (e) {}
+
+    /**
+     * Reaching here means `docker compose` is not exist
+     *
+     * Check `docker-compose`
+     *
+     * Update the associated variable
+     */
+    dockerComposeBinary = 'docker-compose'
+
+    // Check the binary and call the post checking process function
+    checkProcess('docker-compose -v', (exist) => postCheck(exist))
   })
 }
+
+/**
+ * Get the set Docker compose binary
+ *
+ * @Return: {string} the set docker compose binary, either `docker-compose` or `docker compose`
+ */
+let getDockerComposeBinary = () => dockerComposeBinary
 
 /**
  * Check if Cassandra® is up and ready to be connected with in the container
@@ -942,6 +987,7 @@ module.exports = {
   checkProjectIsRunning,
   getPortsFromYAMLFile,
   getDockerInstance,
+  getDockerComposeBinary,
   getProjects,
   saveProject,
   deleteProject

--- a/main/main.js
+++ b/main/main.js
@@ -326,6 +326,16 @@ try {
 
 // When the app is ready a renderer thread should be created and started
 App.on('ready', () => {
+  // Force to run only one instance of the app at once
+  try {
+    // https://www.electronjs.org/docs/latest/api/app#apprequestsingleinstancelockadditionaldata
+    if (App.requestSingleInstanceLock())
+      throw 0
+
+    // Quit/terminate that new instance
+    App.quit()
+  } catch (e) {}
+
   // Create the main view, and pass the properties
   views.main = createWindow(properties, AppProps.Paths.MainView, extraProperties, () => {
     // Send the set extra resources path to the main renderer thread
@@ -489,6 +499,18 @@ App.on('activate', () => {
 App.on('window-all-closed', () => {
   try {
     App.quit()
+  } catch (e) {}
+})
+
+// On attempt to run a second instance
+App.on('second-instance', () => {
+  try {
+    // Restore the main's instance's window
+    if (views.main.isMinimized())
+      views.main.restore()
+
+    // And focus it
+    views.main.focus()
   } catch (e) {}
 })
 

--- a/renderer/js/events/clusters.js
+++ b/renderer/js/events/clusters.js
@@ -3293,7 +3293,8 @@
                           setTimeout(() => IPCRenderer.send('pty:create:bash-session', {
                             id: `${clusterID}-bash-${sessionID}`,
                             projectID: `cassandra_${clusterID}`,
-                            path: Path.join((extraResourcesPath != null ? Path.join(extraResourcesPath) : Path.join(__dirname, '..', '..')), 'data', 'docker', clusterID)
+                            path: Path.join((extraResourcesPath != null ? Path.join(extraResourcesPath) : Path.join(__dirname, '..', '..')), 'data', 'docker', clusterID),
+                            dockerComposeBinary: Modules.Docker.getDockerComposeBinary()
                           }), 500)
 
                           /**


### PR DESCRIPTION
- The app now won't allow for multiple instances, if the user tries to run a new instance of the app it'll simply stop/terminate the new instance immediately, restore, and focus the main window.
- The app now uses `docker compose` by default, if something went wrong it automatically switches to `docker-compose`, if none of them exists it'll provide feedback to the user regards that.